### PR TITLE
Update omniauth-oauth2 dependency version

### DIFF
--- a/omniauth-salesforce.gemspec
+++ b/omniauth-salesforce.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency 'omniauth', '~> 2.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.8.0'
   gem.required_ruby_version = '>= 2.1.0'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
This PR updates the omniauth-oauth2 dependency version from 1.7.x to 1.8.x